### PR TITLE
Fix issue displaying FP values

### DIFF
--- a/src/fp.rs
+++ b/src/fp.rs
@@ -40,13 +40,13 @@ impl PartialEq for FP {
 
 impl fmt::Display for FP {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "FP: [ {} ]", self.x)
+        write!(f, "FP: [ {} ]", self.tostring())
     }
 }
 
 impl fmt::Debug for FP {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "FP: [ {} ]", self.x)
+        write!(f, "FP: [ {} ]", self.tostring())
     }
 }
 


### PR DESCRIPTION
# What is the issue

When using the display function e.g. `println!("{}", FP::new());` the function was not reducing the excess for FP values.

Note: this is also applied recursively to FP2.

# What has been changed 

Use the `tostring()` function to display FP values.

Signed-off-by: Kirk Baird <baird.k@outlook.com>