### PR TITLE
Tidy up mutability requirements

### DIFF
--- a/src/big.rs
+++ b/src/big.rs
@@ -421,7 +421,7 @@ impl Big {
     /// To Byte Array
     ///
     /// Convert this Big to byte array from index `n`
-    pub fn tobytearray(&mut self, b: &mut [u8], n: usize) {
+    pub fn tobytearray(&self, b: &mut [u8], n: usize) {
         let mut c = Big::new_copy(self);
         c.norm();
 
@@ -446,7 +446,7 @@ impl Big {
     /// To Bytes
     ///
     /// Convert to bytes from index 0
-    pub fn tobytes(&mut self, b: &mut [u8]) {
+    pub fn tobytes(&self, b: &mut [u8]) {
         self.tobytearray(b, 0)
     }
 
@@ -470,7 +470,7 @@ impl Big {
     }
 
     /// self*=c and catch overflow in DBig
-    pub fn pxmul(&mut self, c: isize) -> DBig {
+    pub fn pxmul(&self, c: isize) -> DBig {
         let mut m = DBig::new();
         let mut carry = 0 as Chunk;
         for j in 0..NLEN {

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -115,13 +115,11 @@ impl FP {
     }
 
     pub fn to_hex(&self) -> String {
-        let x = self.x;
-        let big = x.tostring();
-        format!("{} {}", self.xes, big)
+        format!("{} {}", self.xes, self.x.tostring())
     }
 
     // convert back to regular form
-    pub fn redc(&mut self) -> Big {
+    pub fn redc(&self) -> Big {
         if MODTYPE != ModType::PseudoMersenne && MODTYPE != ModType::GeneralisedMersenne {
             let mut d = DBig::new_scopy(&(self.x));
             return FP::modulo(&mut d);
@@ -201,7 +199,7 @@ impl FP {
     }
 
     // convert to string
-    pub fn tostring(&mut self) -> String {
+    pub fn tostring(&self) -> String {
         self.redc().tostring()
     }
 
@@ -424,7 +422,7 @@ impl FP {
 
     // See eprint paper https://eprint.iacr.org/2018/1038
     // return this^(p-3)/4 or this^(p-5)/8
-    pub fn fpow(&mut self) -> FP {
+    pub fn fpow(&self) -> FP {
         let ac: [isize; 11] = [1, 2, 3, 6, 12, 15, 30, 60, 120, 240, 255];
         let mut xp: [FP; 11] = [
             FP::new(),
@@ -705,7 +703,7 @@ impl FP {
         }
     }
     // return jacobi symbol (this/Modulus)
-    pub fn jacobi(&mut self) -> isize {
+    pub fn jacobi(&self) -> isize {
         let p = Big::new_ints(&rom::MODULUS);
         let mut w = self.redc();
         return w.jacobi(&p);

--- a/src/fp12.rs
+++ b/src/fp12.rs
@@ -165,30 +165,24 @@ impl FP12 {
     /* test self=1 ? */
     pub fn isunity(&self) -> bool {
         let one = FP4::new_int(1);
-        return self.a.equals(&one) && self.b.iszilch() && self.c.iszilch();
+        self.a.equals(&one) && self.b.iszilch() && self.c.iszilch()
     }
 
     /* test self=x */
     pub fn equals(&self, x: &FP12) -> bool {
-        return self.a.equals(&x.a) && self.b.equals(&x.b) && self.c.equals(&x.c);
+        self.a.equals(&x.a) && self.b.equals(&x.b) && self.c.equals(&x.c)
     }
 
-    pub fn geta(&mut self) -> FP4 {
-        return self.a;
-        //        let f = FP4::new_copy(&self.a);
-        //        return f;
+    pub fn geta(&self) -> FP4 {
+        self.a
     }
 
-    pub fn getb(&mut self) -> FP4 {
-        return self.b;
-        //        let f = FP4::new_copy(&self.b);
-        //        return f;
+    pub fn getb(&self) -> FP4 {
+        self.b
     }
 
     pub fn getc(&mut self) -> FP4 {
-        return self.c;
-        //        let f = FP4::new_copy(&self.c);
-        //        return f;
+        self.c
     }
 
     /* copy self=x */
@@ -887,7 +881,7 @@ impl FP12 {
     }
 
     /* convert this to byte array */
-    pub fn tobytes(&mut self, w: &mut [u8]) {
+    pub fn tobytes(&self, w: &mut [u8]) {
         let mut t: [u8; big::MODBYTES as usize] = [0; big::MODBYTES as usize];
         let mb = big::MODBYTES as usize;
 
@@ -944,7 +938,7 @@ impl FP12 {
     }
 
     /* output to hex string */
-    pub fn tostring(&mut self) -> String {
+    pub fn tostring(&self) -> String {
         return format!(
             "[{},{},{}]",
             self.a.tostring(),

--- a/src/fp16.rs
+++ b/src/fp16.rs
@@ -108,7 +108,7 @@ impl FP16 {
     }
 
     /* test is w real? That is in a+ib test b is zero */
-    pub fn isreal(&mut self) -> bool {
+    pub fn isreal(&self) -> bool {
         return self.b.iszilch();
     }
     /* extract real part a */
@@ -294,7 +294,7 @@ impl FP16 {
     }
 
     /* output to hex string */
-    pub fn tostring(&mut self) -> String {
+    pub fn tostring(&self) -> String {
         return format!("[{},{}]", self.a.tostring(), self.b.tostring());
     }
 

--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -133,12 +133,12 @@ impl FP2 {
     }
 
     /* extract a */
-    pub fn geta(&mut self) -> Big {
+    pub fn geta(&self) -> Big {
         return self.a.redc();
     }
 
     /* extract b */
-    pub fn getb(&mut self) -> Big {
+    pub fn getb(&self) -> Big {
         return self.b.redc();
     }
 
@@ -322,7 +322,7 @@ impl FP2 {
     }
 
     /* output to hex string */
-    pub fn tostring(&mut self) -> String {
+    pub fn tostring(&self) -> String {
         return format!("[{},{}]", self.a.tostring(), self.b.tostring());
     }
 

--- a/src/fp24.rs
+++ b/src/fp24.rs
@@ -167,22 +167,16 @@ impl FP24 {
         return self.a.equals(&x.a) && self.b.equals(&x.b) && self.c.equals(&x.c);
     }
 
-    pub fn geta(&mut self) -> FP8 {
+    pub fn geta(&self) -> FP8 {
         return self.a;
-        //        let f = FP8::new_copy(&self.a);
-        //        return f;
     }
 
-    pub fn getb(&mut self) -> FP8 {
+    pub fn getb(&self) -> FP8 {
         return self.b;
-        //	let f = FP8::new_copy(&self.b);
-        //        return f;
     }
 
-    pub fn getc(&mut self) -> FP8 {
+    pub fn getc(&self) -> FP8 {
         return self.c;
-        //        let f = FP8::new_copy(&self.c);
-        //        return f;
     }
 
     /* copy self=x */
@@ -962,7 +956,7 @@ impl FP24 {
     }
 
     /* convert this to byte array */
-    pub fn tobytes(&mut self, w: &mut [u8]) {
+    pub fn tobytes(&self, w: &mut [u8]) {
         let mut t: [u8; big::MODBYTES as usize] = [0; big::MODBYTES as usize];
         let mb = big::MODBYTES as usize;
 
@@ -1070,7 +1064,7 @@ impl FP24 {
     }
 
     /* output to hex string */
-    pub fn tostring(&mut self) -> String {
+    pub fn tostring(&self) -> String {
         return format!(
             "[{},{},{}]",
             self.a.tostring(),

--- a/src/fp4.rs
+++ b/src/fp4.rs
@@ -114,7 +114,7 @@ impl FP4 {
     }
 
     /* test is w real? That is in a+ib test b is zero */
-    pub fn isreal(&mut self) -> bool {
+    pub fn isreal(&self) -> bool {
         return self.b.iszilch();
     }
     /* extract real part a */
@@ -302,7 +302,7 @@ impl FP4 {
     }
 
     /* output to hex string */
-    pub fn tostring(&mut self) -> String {
+    pub fn tostring(&self) -> String {
         return format!("[{},{}]", self.a.tostring(), self.b.tostring());
     }
 

--- a/src/fp48.rs
+++ b/src/fp48.rs
@@ -168,22 +168,16 @@ impl FP48 {
         return self.a.equals(&x.a) && self.b.equals(&x.b) && self.c.equals(&x.c);
     }
 
-    pub fn geta(&mut self) -> FP16 {
+    pub fn geta(&self) -> FP16 {
         return self.a;
-        //        let f = FP16::new_copy(&self.a);
-        //        return f;
     }
 
-    pub fn getb(&mut self) -> FP16 {
+    pub fn getb(&self) -> FP16 {
         return self.b;
-        //        let f = FP16::new_copy(&self.b);
-        //        return f;
     }
 
-    pub fn getc(&mut self) -> FP16 {
+    pub fn getc(&self) -> FP16 {
         return self.c;
-        //        let f = FP16::new_copy(&self.c);
-        //        return f;
     }
 
     /* copy self=x */
@@ -1112,7 +1106,7 @@ impl FP48 {
     }
 
     /* convert this to byte array */
-    pub fn tobytes(&mut self, w: &mut [u8]) {
+    pub fn tobytes(&self, w: &mut [u8]) {
         let mut t: [u8; big::MODBYTES as usize] = [0; big::MODBYTES as usize];
         let mb = big::MODBYTES as usize;
 
@@ -1322,7 +1316,7 @@ impl FP48 {
     }
 
     /* output to hex string */
-    pub fn tostring(&mut self) -> String {
+    pub fn tostring(&self) -> String {
         return format!(
             "[{},{},{}]",
             self.a.tostring(),

--- a/src/fp8.rs
+++ b/src/fp8.rs
@@ -109,7 +109,7 @@ impl FP8 {
     }
 
     /* test is w real? That is in a+ib test b is zero */
-    pub fn isreal(&mut self) -> bool {
+    pub fn isreal(&self) -> bool {
         return self.b.iszilch();
     }
     /* extract real part a */
@@ -304,7 +304,7 @@ impl FP8 {
     }
 
     /* output to hex string */
-    pub fn tostring(&mut self) -> String {
+    pub fn tostring(&self) -> String {
         return format!("[{},{}]", self.a.tostring(), self.b.tostring());
     }
 


### PR DESCRIPTION
# What is changed

Reduces the need for a mutable reference in functions that do not need to be mutable.

Signed-off-by: Kirk Baird <baird.k@outlook.com>