### PR TITLE
Fix tests

### DIFF
--- a/src/big.rs
+++ b/src/big.rs
@@ -30,13 +30,13 @@ pub use super::rom::MODBYTES;
 use std::cmp::Ordering;
 use std::fmt;
 
-pub const NLEN: usize = (1 + ((8 * MODBYTES - 1) / BASEBITS));
+pub const NLEN: usize = 1 + (8 * MODBYTES - 1) / BASEBITS;
 pub const DNLEN: usize = 2 * NLEN;
-pub const BMASK: Chunk = ((1 << BASEBITS) - 1);
-pub const HBITS: usize = (BASEBITS / 2);
-pub const HMASK: Chunk = ((1 << HBITS) - 1);
-pub const NEXCESS: isize = (1 << ((arch::CHUNK) - BASEBITS - 1));
-pub const BIGBITS: usize = (MODBYTES * 8);
+pub const BMASK: Chunk = (1 << BASEBITS) - 1;
+pub const HBITS: usize = BASEBITS / 2;
+pub const HMASK: Chunk = (1 << HBITS) - 1;
+pub const NEXCESS: isize = 1 << (arch::CHUNK - BASEBITS - 1);
+pub const BIGBITS: usize = MODBYTES * 8;
 
 #[derive(Copy)]
 pub struct Big {

--- a/src/bls.rs
+++ b/src/bls.rs
@@ -20,7 +20,6 @@ under the License.
 use super::ecp::ECP;
 use super::ecp2::ECP2;
 use std::str;
-//use super::fp12::FP12;
 use super::big;
 use super::big::Big;
 use super::pair;

--- a/src/bls192.rs
+++ b/src/bls192.rs
@@ -100,13 +100,13 @@ mod tests {
     use crate::test_utils::*;
 
     #[test]
-    fn test_bls() {
+    fn test_bls24() {
         let mut rng = create_rng();
 
         let mut s: [u8; BGS] = [0; BGS];
 
-        const G1S: usize = BFS + 1; /* Group 1 Size */
-        const G2S: usize = 4 * BFS; /* Group 2 Size */
+        const G1S: usize = BFS + 1; // Group 1 Size
+        const G2S: usize = 8 * BFS; // Group 2 Size
 
         let mut w: [u8; G2S] = [0; G2S];
         let mut sig: [u8; G1S] = [0; G1S];

--- a/src/bls192.rs
+++ b/src/bls192.rs
@@ -38,7 +38,6 @@ pub const BLS_OK: isize = 0;
 pub const BLS_FAIL: isize = -1;
 
 // hash a message to an ECP point, using SHA3
-
 #[allow(non_snake_case)]
 fn bls_hashit(m: &str) -> ECP {
     let mut sh = SHA3::new(SHAKE256);

--- a/src/bls256.rs
+++ b/src/bls256.rs
@@ -98,13 +98,13 @@ mod tests {
     use crate::test_utils::*;
 
     #[test]
-    fn test_bls() {
+    fn test_bls48() {
         let mut rng = create_rng();
 
         let mut s: [u8; BGS] = [0; BGS];
 
-        const G1S: usize = BFS + 1; /* Group 1 Size */
-        const G2S: usize = 4 * BFS; /* Group 2 Size */
+        const G1S: usize = BFS + 1; // Group 1 Size
+        const G2S: usize = 16 * BFS; // Group 2 Size
 
         let mut w: [u8; G2S] = [0; G2S];
         let mut sig: [u8; G1S] = [0; G1S];

--- a/src/bls256.rs
+++ b/src/bls256.rs
@@ -20,7 +20,6 @@ under the License.
 use super::ecp::ECP;
 use super::ecp8::ECP8;
 use std::str;
-//use super::fp48::FP48;
 use super::big;
 use super::big::Big;
 use super::pair256;
@@ -60,7 +59,7 @@ pub fn key_pair_generate(mut rng: &mut RAND, s: &mut [u8], w: &mut [u8]) -> isiz
     BLS_OK
 }
 
-// Sign message m using private key s to produce signature sig
+/// Sign message m using private key s to produce signature sig
 pub fn sign(sig: &mut [u8], m: &str, s: &[u8]) -> isize {
     let d = bls_hashit(m);
     let mut sc = Big::frombytes(&s);

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -215,7 +215,7 @@ pub fn pbkdf2(sha: usize, pass: &[u8], salt: &[u8], rep: usize, olen: usize, k: 
             }
         }
         for j in 0..EFS {
-            if kp < olen {
+            if kp < olen && kp < f.len() {
                 k[kp] = f[j]
             }
             kp += 1
@@ -225,10 +225,10 @@ pub fn pbkdf2(sha: usize, pass: &[u8], salt: &[u8], rep: usize, olen: usize, k: 
 
 /// Calculate HMAC of m using key k. HMAC is tag of length olen (which is length of tag)
 pub fn hmac(sha: usize, m: &[u8], k: &[u8], olen: usize, tag: &mut [u8]) -> bool {
-    /* Input is from an octet m        *
-    	* olen is requested output length in bytes. k is the key  *
-    	* The output is the calculated tag */
-    let mut b: [u8; 64] = [0; 64]; /* Not good */
+    // Input is from an octet m
+	// olen is requested output length in bytes. k is the key
+    // The output is the calculated tag
+    let mut b: [u8; 64] = [0; 64]; // Not good
     let mut k0: [u8; 128] = [0; 128];
 
     if olen < 4 {
@@ -270,9 +270,9 @@ pub fn hmac(sha: usize, m: &[u8], k: &[u8], olen: usize, tag: &mut [u8]) -> bool
 
 /// AES encryption/decryption. Encrypt byte array m using key k and returns ciphertext c
 pub fn cbc_iv0_encrypt(k: &[u8], m: &[u8]) -> Vec<u8> {
-    /* AES CBC encryption, with Null IV and key K */
-    /* Input is from an octet string m, output is to an octet string c */
-    /* Input is padded as necessary to make up a full final block */
+    // AES CBC encryption, with Null IV and key K
+    // Input is from an octet string m, output is to an octet string c
+    // Input is padded as necessary to make up a full final block
     let mut a = AES::new();
     let mut fin = false;
     let mut c: Vec<u8> = Vec::new();
@@ -304,7 +304,7 @@ pub fn cbc_iv0_encrypt(k: &[u8], m: &[u8]) -> Vec<u8> {
         }
     }
 
-    /* last block, filled up to i-th index */
+    // last block, filled up to i-th index
 
     let padlen = 16 - i;
     for j in i..16 {
@@ -322,7 +322,7 @@ pub fn cbc_iv0_encrypt(k: &[u8], m: &[u8]) -> Vec<u8> {
 
 /// Returns plaintext if all consistent, else returns null string
 pub fn cbc_iv0_decrypt(k: &[u8], c: &[u8]) -> Option<Vec<u8>> {
-    /* padding is removed */
+    // padding is removed
     let mut a = AES::new();
     let mut fin = false;
     let mut m: Vec<u8> = Vec::new();
@@ -500,7 +500,7 @@ pub fn ecpsp_dsa(
 
     let r = Big::new_ints(&rom::CURVE_ORDER);
 
-    let sc = Big::frombytes(s); /* s or &s? */
+    let sc = Big::frombytes(s); // s or &s?
     let fb = Big::frombytes(&b);
 
     let mut cb = Big::new();
@@ -510,7 +510,7 @@ pub fn ecpsp_dsa(
 
     while db.iszilch() {
         let mut u = Big::randomnum(&r, rng);
-        let w = Big::randomnum(&r, rng); /* side channel masking */
+        let w = Big::randomnum(&r, rng); // side channel masking
 
         V.copy(&G);
         V = V.mul(&u);
@@ -559,8 +559,8 @@ pub fn ecpvp_dsa(sha: usize, w: &[u8], f: &[u8], c: &[u8], d: &[u8]) -> isize {
 
     let r = Big::new_ints(&rom::CURVE_ORDER);
 
-    let cb = Big::frombytes(c); /* c or &c ? */
-    let mut db = Big::frombytes(d); /* d or &d ? */
+    let cb = Big::frombytes(c); // c or &c ?
+    let mut db = Big::frombytes(d); // d or &d ?
     let mut fb = Big::frombytes(&b);
     let mut tb = Big::new();
 

--- a/src/ff.rs
+++ b/src/ff.rs
@@ -31,13 +31,13 @@ use super::super::arch::DChunk;
 pub use super::rom::FFLEN;
 //use std::str::SplitWhitespace;
 
-pub const FF_BITS: usize = (big::BIGBITS * FFLEN); /* Finite Field Size in bits - must be 256.2^n */
-pub const HFLEN: usize = (FFLEN / 2); /* Useful for half-size RSA private key operations */
+pub const FF_BITS: usize = big::BIGBITS * FFLEN; /* Finite Field Size in bits - must be 256.2^n */
+pub const HFLEN: usize = FFLEN / 2; /* Useful for half-size RSA private key operations */
 
 pub const P_MBITS: usize = (big::MODBYTES as usize) * 8;
-pub const P_OMASK: Chunk = ((-1) << (P_MBITS % big::BASEBITS));
-pub const P_FEXCESS: Chunk = (1 << (big::BASEBITS * big::NLEN - P_MBITS - 1));
-pub const P_TBITS: usize = (P_MBITS % big::BASEBITS);
+pub const P_OMASK: Chunk = (-1) << (P_MBITS % big::BASEBITS);
+pub const P_FEXCESS: Chunk = 1 << (big::BASEBITS * big::NLEN - P_MBITS - 1);
+pub const P_TBITS: usize = P_MBITS % big::BASEBITS;
 
 pub struct FF {
     v: Vec<Big>,

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -54,7 +54,7 @@ pub use super::rom::{MOD8, MODBITS, MODTYPE, SH};
 use std::fmt;
 use std::str::SplitWhitespace;
 
-pub const FEXCESS: i32 = (((1 as i32) << SH) - 1);
+pub const FEXCESS: i32 = ((1 as i32) << SH) - 1;
 pub const OMASK: Chunk = (-1) << (MODBITS % big::BASEBITS);
 pub const TBITS: usize = MODBITS % big::BASEBITS; // Number of active bits in top word
 pub const TMASK: Chunk = (1 << TBITS) - 1;

--- a/src/mpin.rs
+++ b/src/mpin.rs
@@ -35,10 +35,9 @@ use hash384::HASH384;
 use hash512::HASH512;
 use rand::RAND;
 
-/* MPIN API Functions */
+// MPIN API Functions
 
-/* Configure mode of operation */
-
+// Configure mode of operation
 pub const EFS: usize = big::MODBYTES as usize;
 pub const EGS: usize = big::MODBYTES as usize;
 pub const BAD_PARAMS: isize = -11;
@@ -49,12 +48,11 @@ pub const SHA256: usize = 32;
 pub const SHA384: usize = 48;
 pub const SHA512: usize = 64;
 
-/* Configure your PIN here */
-
-pub const MAXPIN: i32 = 10000; /* PIN less than this */
-pub const PBLEN: i32 = 14; /* Number of bits in PIN */
-pub const TS: usize = 10; /* 10 for 4 digit PIN, 14 for 6-digit PIN - 2^TS/TS approx = sqrt(MAXPIN) */
-pub const TRAP: usize = 200; /* 200 for 4 digit PIN, 2000 for 6-digit PIN  - approx 2*sqrt(MAXPIN) */
+// Configure your PIN here
+pub const MAXPIN: i32 = 10000; // PIN less than this
+pub const PBLEN: i32 = 14; // Number of bits in PIN
+pub const TS: usize = 10; // 10 for 4 digit PIN, 14 for 6-digit PIN - 2^TS/TS approx = sqrt(MAXPIN)
+pub const TRAP: usize = 200; // 200 for 4 digit PIN, 2000 for 6-digit PIN  - approx 2*sqrt(MAXPIN)
 
 #[allow(non_snake_case)]
 fn hash(sha: usize, c: &mut FP4, U: &mut ECP, r: &mut [u8]) -> bool {
@@ -117,8 +115,7 @@ fn hash(sha: usize, c: &mut FP4, U: &mut ECP, r: &mut [u8]) -> bool {
     return false;
 }
 
-/* Hash number (optional) and string to point on curve */
-
+/// Hash number (optional) and string to point on curve
 fn hashit(sha: usize, n: usize, id: &[u8], w: &mut [u8]) -> bool {
     let mut r: [u8; 64] = [0; 64];
     let mut didit = false;
@@ -180,7 +177,7 @@ fn hashit(sha: usize, n: usize, id: &[u8], w: &mut [u8]) -> bool {
     return true;
 }
 
-/* return time in slots since epoch */
+/// Return time in slots since epoch
 pub fn today() -> usize {
     return (SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -189,8 +186,8 @@ pub fn today() -> usize {
         / (60 * 1440)) as usize;
 }
 
-/* these next two functions help to implement elligator squared - http://eprint.iacr.org/2014/043 */
-/* maps a random u to a point on the curve */
+// these next two functions help to implement elligator squared - http://eprint.iacr.org/2014/043
+/// Maps a random u to a point on the curve
 #[allow(non_snake_case)]
 fn emap(u: &Big, cb: isize) -> ECP {
     let mut P: ECP;
@@ -208,7 +205,7 @@ fn emap(u: &Big, cb: isize) -> ECP {
     return P;
 }
 
-/* returns u derived from P. Random value in range 1 to return value should then be added to u */
+/// Returns u derived from P. Random value in range 1 to return value should then be added to u
 #[allow(non_snake_case)]
 fn unmap(u: &mut Big, P: &mut ECP) -> isize {
     let s = P.gets();
@@ -232,9 +229,9 @@ pub fn hash_id(sha: usize, id: &[u8], w: &mut [u8]) -> bool {
     return hashit(sha, 0, id, w);
 }
 
-/* these next two functions implement elligator squared - http://eprint.iacr.org/2014/043 */
-/* Elliptic curve point E in format (0x04,x,y} is converted to form {0x0-,u,v} */
-/* Note that u and v are indistinguisible from random strings */
+// These next two functions implement elligator squared - http://eprint.iacr.org/2014/043
+// Elliptic curve point E in format (0x04,x,y} is converted to form {0x0-,u,v}
+// Note that u and v are indistinguisible from random strings
 #[allow(non_snake_case)]
 pub fn encoding(rng: &mut RAND, e: &mut [u8]) -> isize {
     let mut t: [u8; EFS] = [0; EFS];
@@ -316,7 +313,7 @@ pub fn decoding(d: &mut [u8]) -> isize {
     return 0;
 }
 
-/* R=R1+R2 in group G1 */
+/// R=R1+R2 in group G1
 #[allow(non_snake_case)]
 pub fn recombine_g1(r1: &[u8], r2: &[u8], r: &mut [u8]) -> isize {
     let mut P = ECP::frombytes(&r1);
@@ -332,7 +329,7 @@ pub fn recombine_g1(r1: &[u8], r2: &[u8], r: &mut [u8]) -> isize {
     return 0;
 }
 
-/* W=W1+W2 in group G2 */
+/// W=W1+W2 in group G2
 #[allow(non_snake_case)]
 pub fn recombine_g2(w1: &[u8], w2: &[u8], w: &mut [u8]) -> isize {
     let mut P = ECP2::frombytes(&w1);
@@ -348,7 +345,7 @@ pub fn recombine_g2(w1: &[u8], w2: &[u8], w: &mut [u8]) -> isize {
     return 0;
 }
 
-/* create random secret S */
+/// create random secret S
 pub fn random_generate(rng: &mut RAND, s: &mut [u8]) -> isize {
     let r = Big::new_ints(&rom::CURVE_ORDER);
     let sc = Big::randomnum(&r, rng);
@@ -356,7 +353,7 @@ pub fn random_generate(rng: &mut RAND, s: &mut [u8]) -> isize {
     return 0;
 }
 
-/* Extract Server Secret SST=S*Q where Q is fixed generator in G2 and S is master secret */
+/// Extract Server Secret SST=S*Q where Q is fixed generator in G2 and S is master secret
 #[allow(non_snake_case)]
 pub fn get_server_secret(s: &[u8], sst: &mut [u8]) -> isize {
     let mut Q = ECP2::generator();
@@ -367,12 +364,10 @@ pub fn get_server_secret(s: &[u8], sst: &mut [u8]) -> isize {
     return 0;
 }
 
-/*
- W=x*H(G);
- if RNG == NULL then X is passed in
- if RNG != NULL the X is passed out
- if type=0 W=x*G where G is point on the curve, else W=x*M(G), where M(G) is mapping of octet G to point on the curve
-*/
+/// W=x*H(G);
+/// if RNG == NULL then X is passed in
+/// if RNG != NULL the X is passed out
+/// if type=0 W=x*G where G is point on the curve, else W=x*M(G), where M(G) is mapping of octet G to point on the curve
 #[allow(non_snake_case)]
 pub fn get_g1_multiple(
     rng: Option<&mut RAND>,
@@ -405,19 +400,19 @@ pub fn get_g1_multiple(
     return 0;
 }
 
-/* Client secret CST=S*H(CID) where CID is client ID and S is master secret */
-/* CID is hashed externally */
+/// Client secret CST=S*H(CID) where CID is client ID and S is master secret
+/// CID is hashed externally
 pub fn get_client_secret(s: &mut [u8], cid: &[u8], cst: &mut [u8]) -> isize {
     return get_g1_multiple(None, 1, s, cid, cst);
 }
 
-/* Extract PIN from TOKEN for identity CID */
+/// Extract PIN from TOKEN for identity CID
 #[allow(non_snake_case)]
 pub fn extract_pin(sha: usize, cid: &[u8], pin: i32, token: &mut [u8]) -> isize {
     return extract_factor(sha, cid, pin % MAXPIN, PBLEN, token);
 }
 
-/* Extract factor from TOKEN for identity CID */
+/// Extract factor from TOKEN for identity CID
 #[allow(non_snake_case)]
 pub fn extract_factor(
     sha: usize,
@@ -443,7 +438,7 @@ pub fn extract_factor(
     return 0;
 }
 
-/* Restore factor to TOKEN for identity CID */
+/// Restore factor to TOKEN for identity CID
 #[allow(non_snake_case)]
 pub fn restore_factor(
     sha: usize,
@@ -469,7 +464,7 @@ pub fn restore_factor(
     return 0;
 }
 
-/* Functions to support M-Pin Full */
+/// Functions to support M-Pin Full
 #[allow(non_snake_case)]
 pub fn precompute(token: &[u8], cid: &[u8], g1: &mut [u8], g2: &mut [u8]) -> isize {
     let T = ECP::frombytes(&token);
@@ -492,7 +487,7 @@ pub fn precompute(token: &[u8], cid: &[u8], g1: &mut [u8], g2: &mut [u8]) -> isi
     return 0;
 }
 
-/* Time Permit CTT=S*(date|H(CID)) where S is master secret */
+/// Time Permit CTT=S*(date|H(CID)) where S is master secret
 #[allow(non_snake_case)]
 pub fn get_client_permit(sha: usize, date: usize, s: &[u8], cid: &[u8], ctt: &mut [u8]) -> isize {
     const RM: usize = big::MODBYTES as usize;
@@ -505,7 +500,7 @@ pub fn get_client_permit(sha: usize, date: usize, s: &[u8], cid: &[u8], ctt: &mu
     return 0;
 }
 
-/* Implement step 1 on client side of MPin protocol */
+/// Implement step 1 on client side of MPin protocol
 #[allow(non_snake_case)]
 pub fn client_1(
     sha: usize,
@@ -578,7 +573,7 @@ pub fn client_1(
     return 0;
 }
 
-/* Outputs H(CID) and H(T|H(CID)) for time permits. If no time permits set HID=HTID */
+/// Outputs H(CID) and H(T|H(CID)) for time permits. If no time permits set HID=HTID
 #[allow(non_snake_case)]
 pub fn server_1(sha: usize, date: usize, cid: &[u8], hid: &mut [u8], htid: Option<&mut [u8]>) {
     const RM: usize = big::MODBYTES as usize;
@@ -600,7 +595,7 @@ pub fn server_1(sha: usize, date: usize, cid: &[u8], hid: &mut [u8], htid: Optio
     }
 }
 
-/* Implement step 2 on client side of MPin protocol */
+/// Implement step 2 on client side of MPin protocol
 #[allow(non_snake_case)]
 pub fn client_2(x: &[u8], y: &[u8], sec: &mut [u8]) -> isize {
     let r = Big::new_ints(&rom::CURVE_ORDER);
@@ -621,7 +616,7 @@ pub fn client_2(x: &[u8], y: &[u8], sec: &mut [u8]) -> isize {
     return 0;
 }
 
-/* return time since epoch */
+/// return time since epoch
 pub fn get_time() -> usize {
     return (SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -629,7 +624,7 @@ pub fn get_time() -> usize {
         .as_secs()) as usize;
 }
 
-/* Generate Y = H(epoch, xCID/xID) */
+/// Generate Y = H(epoch, xCID/xID)
 pub fn get_y(sha: usize, timevalue: usize, xcid: &[u8], y: &mut [u8]) {
     const RM: usize = big::MODBYTES as usize;
     let mut h: [u8; RM] = [0; RM];
@@ -642,7 +637,7 @@ pub fn get_y(sha: usize, timevalue: usize, xcid: &[u8], y: &mut [u8]) {
     sy.tobytes(y);
 }
 
-/* Implement step 2 of MPin protocol on server side */
+/// Implement step 2 of MPin protocol on server side
 #[allow(non_snake_case)]
 pub fn server_2(
     date: usize,
@@ -739,7 +734,7 @@ pub fn server_2(
     return 0;
 }
 
-/* Pollards kangaroos used to return PIN error */
+/// Pollards kangaroos used to return PIN error
 pub fn kangaroo(e: &[u8], f: &[u8]) -> isize {
     let mut ge = FP12::frombytes(e);
     let mut gf = FP12::frombytes(f);
@@ -790,8 +785,7 @@ pub fn kangaroo(e: &[u8], f: &[u8]) -> isize {
     return res;
 }
 
-/* Hash the M-Pin transcript - new */
-
+/// Hash the M-Pin transcript - new
 pub fn hash_all(
     sha: usize,
     hid: &[u8],
@@ -847,8 +841,8 @@ pub fn hash_all(
     return hashit(sha, 0, &t, h);
 }
 
-/* calculate common key on client side */
-/* wCID = w.(A+AT) */
+/// Calculate common key on client side
+/// wCID = w.(A+AT)
 #[allow(non_snake_case)]
 pub fn client_key(
     sha: usize,
@@ -889,8 +883,8 @@ pub fn client_key(
     return 0;
 }
 
-/* calculate common key on server side */
-/* Z=r.A - no time permits involved */
+/// calculate common key on server side
+/// Z=r.A - no time permits involved
 #[allow(non_snake_case)]
 pub fn server_key(
     sha: usize,
@@ -947,10 +941,9 @@ pub fn server_key(
 mod tests {
     use super::*;
     use crate::test_utils::*;
-    use std::io;
 
     #[test]
-    fn test_mpin() {
+    fn test_mpin_valid() {
         let mut rng = create_rng();
 
         pub const PERMITS: bool = true;
@@ -962,8 +955,8 @@ mod tests {
         let mut hcid: [u8; RM] = [0; RM];
         let mut hsid: [u8; RM] = [0; RM];
 
-        const G1S: usize = 2 * EFS + 1; /* Group 1 Size */
-        const G2S: usize = 4 * EFS; /* Group 2 Size */
+        const G1S: usize = 2 * EFS + 1; // Group 1 Size
+        const G2S: usize = 4 * EFS; // Group 2 Size
         const EAS: usize = ecp::AESKEY;
 
         let mut sst: [u8; G2S] = [0; G2S];
@@ -992,22 +985,22 @@ mod tests {
         let sha = ecp::HASH_TYPE;
 
         println!("\nTesting MPIN - PIN is 1234");
-        /* Trusted Authority set-up */
+        // Trusted Authority set-up
 
         random_generate(&mut rng, &mut s);
         print!("Master Secret s: 0x");
         printbinary(&s);
 
-        /* Create Client Identity */
+        // Create Client Identity
         let name = "testUser@miracl.com";
         let client_id = name.as_bytes();
 
         print!("Client ID= ");
         printbinary(&client_id);
 
-        hash_id(sha, &client_id, &mut hcid); /* Either Client or TA calculates Hash(ID) - you decide! */
+        hash_id(sha, &client_id, &mut hcid); // Either Client or TA calculates Hash(ID) - you decide!
 
-        /* Client and Server are issued secrets by DTA */
+        // Client and Server are issued secrets by DTA
         get_server_secret(&s, &mut sst);
         print!("Server Secret SS: 0x");
         printbinary(&sst);
@@ -1016,7 +1009,7 @@ mod tests {
         print!("Client Secret CS: 0x");
         printbinary(&token);
 
-        /* Client extracts PIN from secret to create Token */
+        // Client extracts PIN from secret to create Token
         let pin: i32 = 1234;
         println!("Client extracts PIN= {}", pin);
         let mut rtn = extract_pin(sha, &client_id, pin, &mut token);
@@ -1034,13 +1027,13 @@ mod tests {
         let mut date = 0;
         if PERMITS {
             date = today();
-            /* Client gets "Time Token" permit from DTA */
+            // Client gets "Time Token" permit from DTA
 
             get_client_permit(sha, date, &s, &hcid, &mut permit);
             print!("Time Permit TP: 0x");
             printbinary(&permit);
 
-            /* This encoding makes Time permit look random - Elligator squared */
+            // This encoding makes Time permit look random - Elligator squared
             encoding(&mut rng, &mut permit);
             print!("Encoded Time Permit TP: 0x");
             printbinary(&permit);
@@ -1049,15 +1042,10 @@ mod tests {
             printbinary(&permit);
         }
 
-        print!("\nPIN= ");
-        let _ = io::Write::flush(&mut io::stdout());
-        let mut input_text = String::new();
-        let _ = io::stdin().read_line(&mut input_text);
-
-        let pin = input_text.trim().parse::<usize>().unwrap();
+        let pin = 1234;
 
         println!("MPIN Multi Pass");
-        /* Send U=x.ID to server, and recreate secret from token and pin */
+        // Send U=x.ID to server, and recreate secret from token and pin
         rtn = client_1(
             sha,
             date,
@@ -1077,10 +1065,10 @@ mod tests {
 
         if FULL {
             hash_id(sha, &client_id, &mut hcid);
-            get_g1_multiple(Some(&mut rng), 1, &mut r, &hcid, &mut z); /* Also Send Z=r.ID to Server, remember random r */
+            get_g1_multiple(Some(&mut rng), 1, &mut r, &hcid, &mut z); // Also Send Z=r.ID to Server, remember random r
         }
 
-        /* Server calculates H(ID) and H(T|H(ID)) (if time PERMITS enabled), and maps them to points on the curve HID and HTID resp. */
+        // Server calculates H(ID) and H(T|H(ID)) (if time PERMITS enabled), and maps them to points on the curve HID and HTID resp.
 
         server_1(sha, date, &client_id, &mut hid, Some(&mut htid[..]));
 
@@ -1090,22 +1078,22 @@ mod tests {
             rhid.clone_from_slice(&hid[..]);
         }
 
-        /* Server generates Random number Y and sends it to Client */
+        // Server generates Random number Y and sends it to Client
         random_generate(&mut rng, &mut y);
 
         if FULL {
             hash_id(sha, &client_id, &mut hsid);
-            get_g1_multiple(Some(&mut rng), 0, &mut w, &rhid, &mut t); /* Also send T=w.ID to client, remember random w  */
+            get_g1_multiple(Some(&mut rng), 0, &mut w, &rhid, &mut t); // Also send T=w.ID to client, remember random w
         }
 
-        /* Client Second Pass: Inputs Client secret SEC, x and y. Outputs -(x+y)*SEC */
+        // Client Second Pass: Inputs Client secret SEC, x and y. Outputs -(x+y)*SEC
         rtn = client_2(&x, &y, &mut sec);
         if rtn != 0 {
             println!("FAILURE: CLIENT_2 rtn: {}", rtn);
         }
 
-        /* Server Second pass. Inputs hashed client id, random Y, -(x+y)*SEC, xID and xCID and Server secret SST. E and F help kangaroos to find error. */
-        /* If PIN error not required, set E and F = null */
+        // Server Second pass. Inputs hashed client id, random Y, -(x+y)*SEC, xID and xCID and Server secret SST. E and F help kangaroos to find error.
+        // If PIN error not required, set E and F = null
 
         if !PINERROR {
             rtn = server_2(

--- a/src/mpin192.rs
+++ b/src/mpin192.rs
@@ -35,10 +35,9 @@ use hash384::HASH384;
 use hash512::HASH512;
 use rand::RAND;
 
-/* MPIN API Functions */
+// MPIN API Functions
 
-/* Configure mode of operation */
-
+// Configure mode of operation
 pub const EFS: usize = big::MODBYTES as usize;
 pub const EGS: usize = big::MODBYTES as usize;
 pub const BAD_PARAMS: isize = -11;
@@ -49,12 +48,11 @@ pub const SHA256: usize = 32;
 pub const SHA384: usize = 48;
 pub const SHA512: usize = 64;
 
-/* Configure your PIN here */
-
-pub const MAXPIN: i32 = 10000; /* PIN less than this */
-pub const PBLEN: i32 = 14; /* Number of bits in PIN */
-pub const TS: usize = 10; /* 10 for 4 digit PIN, 14 for 6-digit PIN - 2^TS/TS approx = sqrt(MAXPIN) */
-pub const TRAP: usize = 200; /* 200 for 4 digit PIN, 2000 for 6-digit PIN  - approx 2*sqrt(MAXPIN) */
+// Configure your PIN here
+pub const MAXPIN: i32 = 10000; // PIN less than this
+pub const PBLEN: i32 = 14; // Number of bits in PIN
+pub const TS: usize = 10; // 10 for 4 digit PIN, 14 for 6-digit PIN - 2^TS/TS approx = sqrt(MAXPIN)
+pub const TRAP: usize = 200; // 200 for 4 digit PIN, 2000 for 6-digit PIN  - approx 2*sqrt(MAXPIN)
 
 #[allow(non_snake_case)]
 fn hash(sha: usize, c: &mut FP8, U: &mut ECP, r: &mut [u8]) -> bool {
@@ -133,8 +131,7 @@ fn hash(sha: usize, c: &mut FP8, U: &mut ECP, r: &mut [u8]) -> bool {
     return false;
 }
 
-/* Hash number (optional) and string to point on curve */
-
+/// Hash number (optional) and string to point on curve
 fn hashit(sha: usize, n: usize, id: &[u8], w: &mut [u8]) -> bool {
     let mut r: [u8; 64] = [0; 64];
     let mut didit = false;
@@ -196,7 +193,7 @@ fn hashit(sha: usize, n: usize, id: &[u8], w: &mut [u8]) -> bool {
     return true;
 }
 
-/* return time in slots since epoch */
+/// return time in slots since epoch
 pub fn today() -> usize {
     return (SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -205,8 +202,8 @@ pub fn today() -> usize {
         / (60 * 1440)) as usize;
 }
 
-/* these next two functions help to implement elligator squared - http://eprint.iacr.org/2014/043 */
-/* maps a random u to a point on the curve */
+// these next two functions help to implement elligator squared - http://eprint.iacr.org/2014/043
+/// Maps a random u to a point on the curve
 #[allow(non_snake_case)]
 fn emap(u: &Big, cb: isize) -> ECP {
     let mut P: ECP;
@@ -224,7 +221,7 @@ fn emap(u: &Big, cb: isize) -> ECP {
     return P;
 }
 
-/* returns u derived from P. Random value in range 1 to return value should then be added to u */
+/// Returns u derived from P. Random value in range 1 to return value should then be added to u
 #[allow(non_snake_case)]
 fn unmap(u: &mut Big, P: &mut ECP) -> isize {
     let s = P.gets();
@@ -248,9 +245,9 @@ pub fn hash_id(sha: usize, id: &[u8], w: &mut [u8]) -> bool {
     return hashit(sha, 0, id, w);
 }
 
-/* these next two functions implement elligator squared - http://eprint.iacr.org/2014/043 */
-/* Elliptic curve point E in format (0x04,x,y} is converted to form {0x0-,u,v} */
-/* Note that u and v are indistinguisible from random strings */
+// these next two functions implement elligator squared - http://eprint.iacr.org/2014/043
+// Elliptic curve point E in format (0x04,x,y} is converted to form {0x0-,u,v}
+// Note that u and v are indistinguisible from random strings
 #[allow(non_snake_case)]
 pub fn encoding(rng: &mut RAND, e: &mut [u8]) -> isize {
     let mut t: [u8; EFS] = [0; EFS];
@@ -332,7 +329,7 @@ pub fn decoding(d: &mut [u8]) -> isize {
     return 0;
 }
 
-/* R=R1+R2 in group G1 */
+/// R=R1+R2 in group G1
 #[allow(non_snake_case)]
 pub fn recombine_g1(r1: &[u8], r2: &[u8], r: &mut [u8]) -> isize {
     let mut P = ECP::frombytes(&r1);
@@ -348,7 +345,7 @@ pub fn recombine_g1(r1: &[u8], r2: &[u8], r: &mut [u8]) -> isize {
     return 0;
 }
 
-/* W=W1+W2 in group G2 */
+/// W=W1+W2 in group G2
 #[allow(non_snake_case)]
 pub fn recombine_g2(w1: &[u8], w2: &[u8], w: &mut [u8]) -> isize {
     let mut P = ECP4::frombytes(&w1);
@@ -364,7 +361,7 @@ pub fn recombine_g2(w1: &[u8], w2: &[u8], w: &mut [u8]) -> isize {
     return 0;
 }
 
-/* create random secret S */
+/// Create random secret S
 pub fn random_generate(rng: &mut RAND, s: &mut [u8]) -> isize {
     let r = Big::new_ints(&rom::CURVE_ORDER);
     let sc = Big::randomnum(&r, rng);
@@ -372,7 +369,7 @@ pub fn random_generate(rng: &mut RAND, s: &mut [u8]) -> isize {
     return 0;
 }
 
-/* Extract Server Secret SST=S*Q where Q is fixed generator in G2 and S is master secret */
+/// Extract Server Secret SST=S*Q where Q is fixed generator in G2 and S is master secret
 #[allow(non_snake_case)]
 pub fn get_server_secret(s: &[u8], sst: &mut [u8]) -> isize {
     let mut Q = ECP4::generator();
@@ -382,12 +379,10 @@ pub fn get_server_secret(s: &[u8], sst: &mut [u8]) -> isize {
     return 0;
 }
 
-/*
- W=x*H(G);
- if RNG == NULL then X is passed in
- if RNG != NULL the X is passed out
- if type=0 W=x*G where G is point on the curve, else W=x*M(G), where M(G) is mapping of octet G to point on the curve
-*/
+/// W=x*H(G);
+/// if RNG == NULL then X is passed in
+/// if RNG != NULL the X is passed out
+/// if type=0 W=x*G where G is point on the curve, else W=x*M(G), where M(G) is mapping of octet G to point on the curve
 #[allow(non_snake_case)]
 pub fn get_g1_multiple(
     rng: Option<&mut RAND>,
@@ -420,19 +415,19 @@ pub fn get_g1_multiple(
     return 0;
 }
 
-/* Client secret CST=S*H(CID) where CID is client ID and S is master secret */
-/* CID is hashed externally */
+/// Client secret CST=S*H(CID) where CID is client ID and S is master secret
+/// CID is hashed externally
 pub fn get_client_secret(s: &mut [u8], cid: &[u8], cst: &mut [u8]) -> isize {
     return get_g1_multiple(None, 1, s, cid, cst);
 }
 
-/* Extract PIN from TOKEN for identity CID */
+/// Extract PIN from TOKEN for identity CID
 #[allow(non_snake_case)]
 pub fn extract_pin(sha: usize, cid: &[u8], pin: i32, token: &mut [u8]) -> isize {
     return extract_factor(sha, cid, pin % MAXPIN, PBLEN, token);
 }
 
-/* Extract factor from TOKEN for identity CID */
+/// Extract factor from TOKEN for identity CID
 #[allow(non_snake_case)]
 pub fn extract_factor(
     sha: usize,
@@ -458,7 +453,7 @@ pub fn extract_factor(
     return 0;
 }
 
-/* Restore factor to TOKEN for identity CID */
+/// Restore factor to TOKEN for identity CID
 #[allow(non_snake_case)]
 pub fn restore_factor(
     sha: usize,
@@ -484,7 +479,7 @@ pub fn restore_factor(
     return 0;
 }
 
-/* Functions to support M-Pin Full */
+/// Functions to support M-Pin Full
 #[allow(non_snake_case)]
 pub fn precompute(token: &[u8], cid: &[u8], g1: &mut [u8], g2: &mut [u8]) -> isize {
     let T = ECP::frombytes(&token);
@@ -507,7 +502,7 @@ pub fn precompute(token: &[u8], cid: &[u8], g1: &mut [u8], g2: &mut [u8]) -> isi
     return 0;
 }
 
-/* Time Permit CTT=S*(date|H(CID)) where S is master secret */
+/// Time Permit CTT=S*(date|H(CID)) where S is master secret
 #[allow(non_snake_case)]
 pub fn get_client_permit(sha: usize, date: usize, s: &[u8], cid: &[u8], ctt: &mut [u8]) -> isize {
     const RM: usize = big::MODBYTES as usize;
@@ -520,7 +515,7 @@ pub fn get_client_permit(sha: usize, date: usize, s: &[u8], cid: &[u8], ctt: &mu
     return 0;
 }
 
-/* Implement step 1 on client side of MPin protocol */
+/// Implement step 1 on client side of MPin protocol
 #[allow(non_snake_case)]
 pub fn client_1(
     sha: usize,
@@ -593,7 +588,7 @@ pub fn client_1(
     return 0;
 }
 
-/* Outputs H(CID) and H(T|H(CID)) for time permits. If no time permits set HID=HTID */
+/// Outputs H(CID) and H(T|H(CID)) for time permits. If no time permits set HID=HTID
 #[allow(non_snake_case)]
 pub fn server_1(sha: usize, date: usize, cid: &[u8], hid: &mut [u8], htid: Option<&mut [u8]>) {
     const RM: usize = big::MODBYTES as usize;
@@ -615,7 +610,7 @@ pub fn server_1(sha: usize, date: usize, cid: &[u8], hid: &mut [u8], htid: Optio
     }
 }
 
-/* Implement step 2 on client side of MPin protocol */
+/// Implement step 2 on client side of MPin protocol
 #[allow(non_snake_case)]
 pub fn client_2(x: &[u8], y: &[u8], sec: &mut [u8]) -> isize {
     let mut r = Big::new_ints(&rom::CURVE_ORDER);
@@ -636,7 +631,7 @@ pub fn client_2(x: &[u8], y: &[u8], sec: &mut [u8]) -> isize {
     return 0;
 }
 
-/* return time since epoch */
+/// return time since epoch
 pub fn get_time() -> usize {
     return (SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -644,7 +639,7 @@ pub fn get_time() -> usize {
         .as_secs()) as usize;
 }
 
-/* Generate Y = H(epoch, xCID/xID) */
+/// Generate Y = H(epoch, xCID/xID)
 pub fn get_y(sha: usize, timevalue: usize, xcid: &[u8], y: &mut [u8]) {
     const RM: usize = big::MODBYTES as usize;
     let mut h: [u8; RM] = [0; RM];
@@ -657,7 +652,7 @@ pub fn get_y(sha: usize, timevalue: usize, xcid: &[u8], y: &mut [u8]) {
     sy.tobytes(y);
 }
 
-/* Implement step 2 of MPin protocol on server side */
+/// Implement step 2 of MPin protocol on server side
 #[allow(non_snake_case)]
 pub fn server_2(
     date: usize,
@@ -754,7 +749,7 @@ pub fn server_2(
     return 0;
 }
 
-/* Pollards kangaroos used to return PIN error */
+/// Pollards kangaroos used to return PIN error
 pub fn kangaroo(e: &[u8], f: &[u8]) -> isize {
     let mut ge = FP24::frombytes(e);
     let mut gf = FP24::frombytes(f);
@@ -805,8 +800,7 @@ pub fn kangaroo(e: &[u8], f: &[u8]) -> isize {
     return res;
 }
 
-/* Hash the M-Pin transcript - new */
-
+/// Hash the M-Pin transcript - new
 pub fn hash_all(
     sha: usize,
     hid: &[u8],
@@ -862,8 +856,8 @@ pub fn hash_all(
     return hashit(sha, 0, &t, h);
 }
 
-/* calculate common key on client side */
-/* wCID = w.(A+AT) */
+/// calculate common key on client side
+/// wCID = w.(A+AT)
 #[allow(non_snake_case)]
 pub fn client_key(
     sha: usize,
@@ -904,8 +898,8 @@ pub fn client_key(
     return 0;
 }
 
-/* calculate common key on server side */
-/* Z=r.A - no time permits involved */
+/// Calculate common key on server side
+/// Z=r.A - no time permits involved
 #[allow(non_snake_case)]
 pub fn server_key(
     sha: usize,
@@ -962,24 +956,22 @@ pub fn server_key(
 mod tests {
     use super::*;
     use crate::test_utils::*;
-    use std::io;
 
     #[test]
-    fn test_mpin192() {
+    fn test_mpin192_valid() {
         let mut rng = create_rng();
 
         pub const PERMITS: bool = true;
         pub const PINERROR: bool = true;
         pub const FULL: bool = true;
-        //pub const SINGLE_PASS:bool=false;
 
         let mut s: [u8; EGS] = [0; EGS];
         const RM: usize = EFS as usize;
         let mut hcid: [u8; RM] = [0; RM];
         let mut hsid: [u8; RM] = [0; RM];
 
-        const G1S: usize = 2 * EFS + 1; /* Group 1 Size */
-        const G2S: usize = 16 * EFS; /* Group 2 Size */
+        const G1S: usize = 2 * EFS + 1; // Group 1 Size
+        const G2S: usize = 16 * EFS; // Group 2 Size
         const EAS: usize = ecp::AESKEY;
 
         let mut sst: [u8; G2S] = [0; G2S];
@@ -1008,22 +1000,22 @@ mod tests {
         let sha = ecp::HASH_TYPE;
 
         println!("\nTesting MPIN - PIN is 1234");
-        /* Trusted Authority set-up */
+        // Trusted Authority set-up
 
         random_generate(&mut rng, &mut s);
         print!("Master Secret s: 0x");
         printbinary(&s);
 
-        /* Create Client Identity */
+        // Create Client Identity
         let name = "testUser@miracl.com";
         let client_id = name.as_bytes();
 
         print!("Client ID= ");
         printbinary(&client_id);
 
-        hash_id(sha, &client_id, &mut hcid); /* Either Client or TA calculates Hash(ID) - you decide! */
+        hash_id(sha, &client_id, &mut hcid); // Either Client or TA calculates Hash(ID) - you decide!
 
-        /* Client and Server are issued secrets by DTA */
+        // Client and Server are issued secrets by DTA
         get_server_secret(&s, &mut sst);
         print!("Server Secret SS: 0x");
         printbinary(&sst);
@@ -1032,7 +1024,7 @@ mod tests {
         print!("Client Secret CS: 0x");
         printbinary(&token);
 
-        /* Client extracts PIN from secret to create Token */
+        // Client extracts PIN from secret to create Token
         let pin: i32 = 1234;
         println!("Client extracts PIN= {}", pin);
         let mut rtn = extract_pin(sha, &client_id, pin, &mut token);
@@ -1050,13 +1042,13 @@ mod tests {
         let mut date = 0;
         if PERMITS {
             date = today();
-            /* Client gets "Time Token" permit from DTA */
+            // Client gets "Time Token" permit from DTA
 
             get_client_permit(sha, date, &s, &hcid, &mut permit);
             print!("Time Permit TP: 0x");
             printbinary(&permit);
 
-            /* This encoding makes Time permit look random - Elligator squared */
+            // This encoding makes Time permit look random - Elligator squared
             encoding(&mut rng, &mut permit);
             print!("Encoded Time Permit TP: 0x");
             printbinary(&permit);
@@ -1065,15 +1057,10 @@ mod tests {
             printbinary(&permit);
         }
 
-        print!("\nPIN= ");
-        let _ = io::Write::flush(&mut io::stdout());
-        let mut input_text = String::new();
-        let _ = io::stdin().read_line(&mut input_text);
-
-        let pin = input_text.trim().parse::<usize>().unwrap();
+        let pin = 1234;
 
         println!("MPIN Multi Pass");
-        /* Send U=x.ID to server, and recreate secret from token and pin */
+        // Send U=x.ID to server, and recreate secret from token and pin
         rtn = client_1(
             sha,
             date,
@@ -1093,10 +1080,10 @@ mod tests {
 
         if FULL {
             hash_id(sha, &client_id, &mut hcid);
-            get_g1_multiple(Some(&mut rng), 1, &mut r, &hcid, &mut z); /* Also Send Z=r.ID to Server, remember random r */
+            get_g1_multiple(Some(&mut rng), 1, &mut r, &hcid, &mut z); // Also Send Z=r.ID to Server, remember random r
         }
 
-        /* Server calculates H(ID) and H(T|H(ID)) (if time PERMITS enabled), and maps them to points on the curve HID and HTID resp. */
+        // Server calculates H(ID) and H(T|H(ID)) (if time PERMITS enabled), and maps them to points on the curve HID and HTID resp.
 
         server_1(sha, date, &client_id, &mut hid, Some(&mut htid[..]));
 
@@ -1106,22 +1093,22 @@ mod tests {
             rhid.clone_from_slice(&hid[..]);
         }
 
-        /* Server generates Random number Y and sends it to Client */
+        // Server generates Random number Y and sends it to Client
         random_generate(&mut rng, &mut y);
 
         if FULL {
             hash_id(sha, &client_id, &mut hsid);
-            get_g1_multiple(Some(&mut rng), 0, &mut w, &rhid, &mut t); /* Also send T=w.ID to client, remember random w  */
+            get_g1_multiple(Some(&mut rng), 0, &mut w, &rhid, &mut t); // Also send T=w.ID to client, remember random w
         }
 
-        /* Client Second Pass: Inputs Client secret SEC, x and y. Outputs -(x+y)*SEC */
+        // Client Second Pass: Inputs Client secret SEC, x and y. Outputs -(x+y)*SEC
         rtn = client_2(&x, &y, &mut sec);
         if rtn != 0 {
             println!("FAILURE: CLIENT_2 rtn: {}", rtn);
         }
 
-        /* Server Second pass. Inputs hashed client id, random Y, -(x+y)*SEC, xID and xCID and Server secret SST. E and F help kangaroos to find error. */
-        /* If PIN error not required, set E and F = null */
+        // Server Second pass. Inputs hashed client id, random Y, -(x+y)*SEC, xID and xCID and Server secret SST. E and F help kangaroos to find error.
+        // If PIN error not required, set E and F = null
 
         if !PINERROR {
             rtn = server_2(

--- a/src/mpin256.rs
+++ b/src/mpin256.rs
@@ -35,10 +35,9 @@ use hash384::HASH384;
 use hash512::HASH512;
 use rand::RAND;
 
-/* MPIN API Functions */
+// MPIN API Functions
 
-/* Configure mode of operation */
-
+// Configure mode of operation
 pub const EFS: usize = big::MODBYTES as usize;
 pub const EGS: usize = big::MODBYTES as usize;
 pub const BAD_PARAMS: isize = -11;
@@ -49,12 +48,11 @@ pub const SHA256: usize = 32;
 pub const SHA384: usize = 48;
 pub const SHA512: usize = 64;
 
-/* Configure your PIN here */
-
-pub const MAXPIN: i32 = 10000; /* PIN less than this */
-pub const PBLEN: i32 = 14; /* Number of bits in PIN */
-pub const TS: usize = 10; /* 10 for 4 digit PIN, 14 for 6-digit PIN - 2^TS/TS approx = sqrt(MAXPIN) */
-pub const TRAP: usize = 200; /* 200 for 4 digit PIN, 2000 for 6-digit PIN  - approx 2*sqrt(MAXPIN) */
+// Configure your PIN here
+pub const MAXPIN: i32 = 10000; // PIN less than this
+pub const PBLEN: i32 = 14; // Number of bits in PIN
+pub const TS: usize = 10; // 10 for 4 digit PIN, 14 for 6-digit PIN - 2^TS/TS approx = sqrt(MAXPIN)
+pub const TRAP: usize = 200; // 200 for 4 digit PIN, 2000 for 6-digit PIN  - approx 2*sqrt(MAXPIN)
 
 #[allow(non_snake_case)]
 fn hash(sha: usize, c: &mut FP16, U: &mut ECP, r: &mut [u8]) -> bool {
@@ -166,8 +164,7 @@ fn hash(sha: usize, c: &mut FP16, U: &mut ECP, r: &mut [u8]) -> bool {
     return false;
 }
 
-/* Hash number (optional) and string to point on curve */
-
+/// Hash number (optional) and string to point on curve
 fn hashit(sha: usize, n: usize, id: &[u8], w: &mut [u8]) -> bool {
     let mut r: [u8; 64] = [0; 64];
     let mut didit = false;
@@ -229,7 +226,7 @@ fn hashit(sha: usize, n: usize, id: &[u8], w: &mut [u8]) -> bool {
     return true;
 }
 
-/* return time in slots since epoch */
+/// Return time in slots since epoch
 pub fn today() -> usize {
     return (SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -238,8 +235,8 @@ pub fn today() -> usize {
         / (60 * 1440)) as usize;
 }
 
-/* these next two functions help to implement elligator squared - http://eprint.iacr.org/2014/043 */
-/* maps a random u to a point on the curve */
+/// these next two functions help to implement elligator squared - http://eprint.iacr.org/2014/043
+/// maps a random u to a point on the curve
 #[allow(non_snake_case)]
 fn emap(u: &Big, cb: isize) -> ECP {
     let mut P: ECP;
@@ -257,7 +254,7 @@ fn emap(u: &Big, cb: isize) -> ECP {
     return P;
 }
 
-/* returns u derived from P. Random value in range 1 to return value should then be added to u */
+/// returns u derived from P. Random value in range 1 to return value should then be added to u
 #[allow(non_snake_case)]
 fn unmap(u: &mut Big, P: &mut ECP) -> isize {
     let s = P.gets();
@@ -281,9 +278,9 @@ pub fn hash_id(sha: usize, id: &[u8], w: &mut [u8]) -> bool {
     return hashit(sha, 0, id, w);
 }
 
-/* these next two functions implement elligator squared - http://eprint.iacr.org/2014/043 */
-/* Elliptic curve point E in format (0x04,x,y} is converted to form {0x0-,u,v} */
-/* Note that u and v are indistinguisible from random strings */
+// these next two functions implement elligator squared - http://eprint.iacr.org/2014/043
+// Elliptic curve point E in format (0x04,x,y} is converted to form {0x0-,u,v}
+// Note that u and v are indistinguisible from random strings
 #[allow(non_snake_case)]
 pub fn encoding(rng: &mut RAND, e: &mut [u8]) -> isize {
     let mut t: [u8; EFS] = [0; EFS];
@@ -365,7 +362,7 @@ pub fn decoding(d: &mut [u8]) -> isize {
     return 0;
 }
 
-/* R=R1+R2 in group G1 */
+/// R=R1+R2 in group G1
 #[allow(non_snake_case)]
 pub fn recombine_g1(r1: &[u8], r2: &[u8], r: &mut [u8]) -> isize {
     let mut P = ECP::frombytes(&r1);
@@ -381,7 +378,7 @@ pub fn recombine_g1(r1: &[u8], r2: &[u8], r: &mut [u8]) -> isize {
     return 0;
 }
 
-/* W=W1+W2 in group G2 */
+/// W=W1+W2 in group G2
 #[allow(non_snake_case)]
 pub fn recombine_g2(w1: &[u8], w2: &[u8], w: &mut [u8]) -> isize {
     let mut P = ECP8::frombytes(&w1);
@@ -397,7 +394,7 @@ pub fn recombine_g2(w1: &[u8], w2: &[u8], w: &mut [u8]) -> isize {
     return 0;
 }
 
-/* create random secret S */
+/// Create random secret S
 pub fn random_generate(rng: &mut RAND, s: &mut [u8]) -> isize {
     let r = Big::new_ints(&rom::CURVE_ORDER);
     let sc = Big::randomnum(&r, rng);
@@ -405,7 +402,7 @@ pub fn random_generate(rng: &mut RAND, s: &mut [u8]) -> isize {
     return 0;
 }
 
-/* Extract Server Secret SST=S*Q where Q is fixed generator in G2 and S is master secret */
+/// Extract Server Secret SST=S*Q where Q is fixed generator in G2 and S is master secret
 #[allow(non_snake_case)]
 pub fn get_server_secret(s: &[u8], sst: &mut [u8]) -> isize {
     let mut Q = ECP8::generator();
@@ -416,12 +413,10 @@ pub fn get_server_secret(s: &[u8], sst: &mut [u8]) -> isize {
     return 0;
 }
 
-/*
- W=x*H(G);
- if RNG == NULL then X is passed in
- if RNG != NULL the X is passed out
- if type=0 W=x*G where G is point on the curve, else W=x*M(G), where M(G) is mapping of octet G to point on the curve
-*/
+/// W=x*H(G);
+/// if RNG == NULL then X is passed in
+/// if RNG != NULL the X is passed out
+// if type=0 W=x*G where G is point on the curve, else W=x*M(G), where M(G) is mapping of octet G to point on the curve
 #[allow(non_snake_case)]
 pub fn get_g1_multiple(
     rng: Option<&mut RAND>,
@@ -454,19 +449,19 @@ pub fn get_g1_multiple(
     return 0;
 }
 
-/* Client secret CST=S*H(CID) where CID is client ID and S is master secret */
-/* CID is hashed externally */
+/// Client secret CST=S*H(CID) where CID is client ID and S is master secret
+/// CID is hashed externally
 pub fn get_client_secret(s: &mut [u8], cid: &[u8], cst: &mut [u8]) -> isize {
     return get_g1_multiple(None, 1, s, cid, cst);
 }
 
-/* Extract PIN from TOKEN for identity CID */
+/// Extract PIN from TOKEN for identity CID
 #[allow(non_snake_case)]
 pub fn extract_pin(sha: usize, cid: &[u8], pin: i32, token: &mut [u8]) -> isize {
     return extract_factor(sha, cid, pin % MAXPIN, PBLEN, token);
 }
 
-/* Extract factor from TOKEN for identity CID */
+/// Extract factor from TOKEN for identity CID
 #[allow(non_snake_case)]
 pub fn extract_factor(
     sha: usize,
@@ -492,7 +487,7 @@ pub fn extract_factor(
     return 0;
 }
 
-/* Restore factor to TOKEN for identity CID */
+/// Restore factor to TOKEN for identity CID
 #[allow(non_snake_case)]
 pub fn restore_factor(
     sha: usize,
@@ -518,7 +513,7 @@ pub fn restore_factor(
     return 0;
 }
 
-/* Functions to support M-Pin Full */
+/// Functions to support M-Pin Full
 #[allow(non_snake_case)]
 pub fn precompute(token: &[u8], cid: &[u8], g1: &mut [u8], g2: &mut [u8]) -> isize {
     let T = ECP::frombytes(&token);
@@ -541,7 +536,7 @@ pub fn precompute(token: &[u8], cid: &[u8], g1: &mut [u8], g2: &mut [u8]) -> isi
     return 0;
 }
 
-/* Time Permit CTT=S*(date|H(CID)) where S is master secret */
+/// Time Permit CTT=S*(date|H(CID)) where S is master secret
 #[allow(non_snake_case)]
 pub fn get_client_permit(sha: usize, date: usize, s: &[u8], cid: &[u8], ctt: &mut [u8]) -> isize {
     const RM: usize = big::MODBYTES as usize;
@@ -554,7 +549,7 @@ pub fn get_client_permit(sha: usize, date: usize, s: &[u8], cid: &[u8], ctt: &mu
     return 0;
 }
 
-/* Implement step 1 on client side of MPin protocol */
+/// Implement step 1 on client side of MPin protocol
 #[allow(non_snake_case)]
 pub fn client_1(
     sha: usize,
@@ -627,7 +622,7 @@ pub fn client_1(
     return 0;
 }
 
-/* Outputs H(CID) and H(T|H(CID)) for time permits. If no time permits set HID=HTID */
+/// Outputs H(CID) and H(T|H(CID)) for time permits. If no time permits set HID=HTID
 #[allow(non_snake_case)]
 pub fn server_1(sha: usize, date: usize, cid: &[u8], hid: &mut [u8], htid: Option<&mut [u8]>) {
     const RM: usize = big::MODBYTES as usize;
@@ -649,7 +644,7 @@ pub fn server_1(sha: usize, date: usize, cid: &[u8], hid: &mut [u8], htid: Optio
     }
 }
 
-/* Implement step 2 on client side of MPin protocol */
+/// Implement step 2 on client side of MPin protocol
 #[allow(non_snake_case)]
 pub fn client_2(x: &[u8], y: &[u8], sec: &mut [u8]) -> isize {
     let mut r = Big::new_ints(&rom::CURVE_ORDER);
@@ -670,7 +665,7 @@ pub fn client_2(x: &[u8], y: &[u8], sec: &mut [u8]) -> isize {
     return 0;
 }
 
-/* return time since epoch */
+/// Return time since epoch
 pub fn get_time() -> usize {
     return (SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -678,7 +673,7 @@ pub fn get_time() -> usize {
         .as_secs()) as usize;
 }
 
-/* Generate Y = H(epoch, xCID/xID) */
+/// Generate Y = H(epoch, xCID/xID)
 pub fn get_y(sha: usize, timevalue: usize, xcid: &[u8], y: &mut [u8]) {
     const RM: usize = big::MODBYTES as usize;
     let mut h: [u8; RM] = [0; RM];
@@ -691,7 +686,7 @@ pub fn get_y(sha: usize, timevalue: usize, xcid: &[u8], y: &mut [u8]) {
     sy.tobytes(y);
 }
 
-/* Implement step 2 of MPin protocol on server side */
+/// Implement step 2 of MPin protocol on server side
 #[allow(non_snake_case)]
 pub fn server_2(
     date: usize,
@@ -788,7 +783,7 @@ pub fn server_2(
     return 0;
 }
 
-/* Pollards kangaroos used to return PIN error */
+/// Pollards kangaroos used to return PIN error
 pub fn kangaroo(e: &[u8], f: &[u8]) -> isize {
     let mut ge = FP48::frombytes(e);
     let mut gf = FP48::frombytes(f);
@@ -839,8 +834,7 @@ pub fn kangaroo(e: &[u8], f: &[u8]) -> isize {
     return res;
 }
 
-/* Hash the M-Pin transcript - new */
-
+/// Hash the M-Pin transcript - new
 pub fn hash_all(
     sha: usize,
     hid: &[u8],
@@ -896,8 +890,8 @@ pub fn hash_all(
     return hashit(sha, 0, &t, h);
 }
 
-/* calculate common key on client side */
-/* wCID = w.(A+AT) */
+/// Calculate common key on client side
+/// wCID = w.(A+AT)
 #[allow(non_snake_case)]
 pub fn client_key(
     sha: usize,
@@ -938,8 +932,8 @@ pub fn client_key(
     return 0;
 }
 
-/* calculate common key on server side */
-/* Z=r.A - no time permits involved */
+/// Calculate common key on server side
+/// Z=r.A - no time permits involved
 #[allow(non_snake_case)]
 pub fn server_key(
     sha: usize,
@@ -996,24 +990,22 @@ pub fn server_key(
 mod tests {
     use super::*;
     use crate::test_utils::*;
-    use std::io;
 
     #[test]
-    fn test_mpin256() {
+    fn test_mpin256_valid() {
         let mut rng = create_rng();
 
         pub const PERMITS: bool = true;
         pub const PINERROR: bool = true;
         pub const FULL: bool = true;
-        //pub const SINGLE_PASS:bool=false;
 
         let mut s: [u8; EGS] = [0; EGS];
         const RM: usize = EFS as usize;
         let mut hcid: [u8; RM] = [0; RM];
         let mut hsid: [u8; RM] = [0; RM];
 
-        const G1S: usize = 2 * EFS + 1; /* Group 1 Size */
-        const G2S: usize = 16 * EFS; /* Group 2 Size */
+        const G1S: usize = 2 * EFS + 1; // Group 1 Size
+        const G2S: usize = 16 * EFS; // Group 2 Size
         const EAS: usize = ecp::AESKEY;
 
         let mut sst: [u8; G2S] = [0; G2S];
@@ -1042,22 +1034,22 @@ mod tests {
         let sha = ecp::HASH_TYPE;
 
         println!("\nTesting MPIN - PIN is 1234");
-        /* Trusted Authority set-up */
+        // Trusted Authority set-up
 
         random_generate(&mut rng, &mut s);
         print!("Master Secret s: 0x");
         printbinary(&s);
 
-        /* Create Client Identity */
+        // Create Client Identity
         let name = "testUser@miracl.com";
         let client_id = name.as_bytes();
 
         print!("Client ID= ");
         printbinary(&client_id);
 
-        hash_id(sha, &client_id, &mut hcid); /* Either Client or TA calculates Hash(ID) - you decide! */
+        hash_id(sha, &client_id, &mut hcid); // Either Client or TA calculates Hash(ID) - you decide!
 
-        /* Client and Server are issued secrets by DTA */
+        // Client and Server are issued secrets by DTA
         get_server_secret(&s, &mut sst);
         print!("Server Secret SS: 0x");
         printbinary(&sst);
@@ -1066,7 +1058,7 @@ mod tests {
         print!("Client Secret CS: 0x");
         printbinary(&token);
 
-        /* Client extracts PIN from secret to create Token */
+        // Client extracts PIN from secret to create Token
         let pin: i32 = 1234;
         println!("Client extracts PIN= {}", pin);
         let mut rtn = extract_pin(sha, &client_id, pin, &mut token);
@@ -1084,13 +1076,13 @@ mod tests {
         let mut date = 0;
         if PERMITS {
             date = today();
-            /* Client gets "Time Token" permit from DTA */
+            // Client gets "Time Token" permit from DTA
 
             get_client_permit(sha, date, &s, &hcid, &mut permit);
             print!("Time Permit TP: 0x");
             printbinary(&permit);
 
-            /* This encoding makes Time permit look random - Elligator squared */
+            // This encoding makes Time permit look random - Elligator squared
             encoding(&mut rng, &mut permit);
             print!("Encoded Time Permit TP: 0x");
             printbinary(&permit);
@@ -1099,15 +1091,10 @@ mod tests {
             printbinary(&permit);
         }
 
-        print!("\nPIN= ");
-        let _ = io::Write::flush(&mut io::stdout());
-        let mut input_text = String::new();
-        let _ = io::stdin().read_line(&mut input_text);
-
-        let pin = input_text.trim().parse::<usize>().unwrap();
+        let pin = 1234;
 
         println!("MPIN Multi Pass");
-        /* Send U=x.ID to server, and recreate secret from token and pin */
+        // Send U=x.ID to server, and recreate secret from token and pin
         rtn = client_1(
             sha,
             date,
@@ -1127,10 +1114,10 @@ mod tests {
 
         if FULL {
             hash_id(sha, &client_id, &mut hcid);
-            get_g1_multiple(Some(&mut rng), 1, &mut r, &hcid, &mut z); /* Also Send Z=r.ID to Server, remember random r */
+            get_g1_multiple(Some(&mut rng), 1, &mut r, &hcid, &mut z); // Also Send Z=r.ID to Server, remember random r
         }
 
-        /* Server calculates H(ID) and H(T|H(ID)) (if time PERMITS enabled), and maps them to points on the curve HID and HTID resp. */
+        // Server calculates H(ID) and H(T|H(ID)) (if time PERMITS enabled), and maps them to points on the curve HID and HTID resp.
 
         server_1(sha, date, &client_id, &mut hid, Some(&mut htid[..]));
 
@@ -1140,22 +1127,22 @@ mod tests {
             rhid.clone_from_slice(&hid[..]);
         }
 
-        /* Server generates Random number Y and sends it to Client */
+        // Server generates Random number Y and sends it to Client
         random_generate(&mut rng, &mut y);
 
         if FULL {
             hash_id(sha, &client_id, &mut hsid);
-            get_g1_multiple(Some(&mut rng), 0, &mut w, &rhid, &mut t); /* Also send T=w.ID to client, remember random w  */
+            get_g1_multiple(Some(&mut rng), 0, &mut w, &rhid, &mut t); // Also send T=w.ID to client, remember random w
         }
 
-        /* Client Second Pass: Inputs Client secret SEC, x and y. Outputs -(x+y)*SEC */
+        // Client Second Pass: Inputs Client secret SEC, x and y. Outputs -(x+y)*SEC
         rtn = client_2(&x, &y, &mut sec);
         if rtn != 0 {
             println!("FAILURE: CLIENT_2 rtn: {}", rtn);
         }
 
-        /* Server Second pass. Inputs hashed client id, random Y, -(x+y)*SEC, xID and xCID and Server secret SST. E and F help kangaroos to find error. */
-        /* If PIN error not required, set E and F = null */
+        // Server Second pass. Inputs hashed client id, random Y, -(x+y)*SEC, xID and xCID and Server secret SST. E and F help kangaroos to find error.
+        // If PIN error not required, set E and F = null
 
         if !PINERROR {
             rtn = server_2(

--- a/src/nhs.rs
+++ b/src/nhs.rs
@@ -29,7 +29,7 @@ const ND: u32 = 0xF7002FFF; // 1/(R-q) mod R
 const ONE: i32 = 0x2AC8; // R mod q
 const R2MODP: u64 = 0x1620; // R^2 mod q
 
-const DEGREE: usize = (1 << LGN);
+const DEGREE: usize = 1 << LGN;
 const WL: usize = 32;
 
 const INV: i32 = 0xeab;


### PR DESCRIPTION
# Issue Resolved

Fixes #15 

# Additional Comments

- This PR also improves rust styling by changing comments to `//` as opposed to `/* ... */`
- Fixes issues from passing small output arrays for `bls24` & `bls48` resulting in an indexing error
- `nist521` has a key size 66 bytes but uses a 64 byte hash and thus copying the last two bytes from the hash to the key results in an indexing error (note: the hash size should be increased to reduce biasing)
- Changes the `mpin` tests to no longer take user input