### PR TITLE
Fix ecp tostring

### DIFF
--- a/src/ecp.rs
+++ b/src/ecp.rs
@@ -431,6 +431,7 @@ impl ECP {
     /* convert to hex string */
     pub fn tostring(&self) -> String {
         let W = self.clone();
+        W.affine();
         if W.is_infinity() {
             return String::from("infinity");
         }


### PR DESCRIPTION
# Issue

`ECP::tostring()` was not calling affine before printing the (x, y) coordinates and so they were out by the `Z` factor.

# Fix

Call `affine()` before outputting the x and y coordinates.