### PR TITLE
Serialisation

### DIFF
--- a/src/bls381/basic.rs
+++ b/src/bls381/basic.rs
@@ -4,6 +4,12 @@ use super::core::{G1_BYTES, G2_BYTES, SECRET_KEY_BYTES};
 use errors::AmclError;
 use rand::RAND;
 
+// Re-export serialization functions.
+pub use super::core::{
+    deserialize_g1, deserialize_g2, serialize_g1, serialize_g2, serialize_uncompressed_g1,
+    serialize_uncompressed_g2,
+};
+
 /// Domain Separation Tag for signatures on G1
 pub const DST_G1: &[u8] = b"BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_NUL_";
 /// Domain Separation Tag for signatures on G2

--- a/src/bls381/core.rs
+++ b/src/bls381/core.rs
@@ -129,9 +129,9 @@ fn zcash_cmp_fp2(num1: &mut FP2, num2: &mut FP2) -> isize {
     result
 }
 
-// Take a G1 point (x, y) and compress it to a 48 byte array.
+/// Take a G1 point (x, y) and compress it to a 48 byte array.
 ///
-// See https://github.com/zkcrypto/pairing/blob/master/src/bls12_381/README.md#serialization
+/// See https://github.com/zkcrypto/pairing/blob/master/src/bls12_381/README.md#serialization
 pub fn serialize_g1(g1: &ECP) -> [u8; G1_BYTES] {
     // Check point at inifinity
     if g1.is_infinity() {
@@ -214,8 +214,7 @@ fn deserialize_compressed_g1(g1_bytes: &[u8]) -> Result<ECP, AmclError> {
             }
         }
 
-        // Point is infinity
-        return Ok(ECP::new());
+        return Ok(ECP::new()); // infinity
     }
 
     let y_flag: bool = (g1_bytes[0] & Y_FLAG) > 0;
@@ -268,8 +267,7 @@ fn deserialize_uncompressed_g1(g1_bytes: &[u8]) -> Result<ECP, AmclError> {
             }
         }
 
-        // Point is infinity
-        return Ok(ECP::new());
+        return Ok(ECP::new()); // infinity
     }
 
     // Require y_flag to be zero
@@ -388,7 +386,7 @@ fn deserialize_compressed_g2(g2_bytes: &[u8]) -> Result<ECP2, AmclError> {
             }
         }
 
-        return Ok(ECP2::new());
+        return Ok(ECP2::new()); // infinity
     }
 
     let y_flag: bool = (g2_bytes[0] & Y_FLAG) > 0;
@@ -443,7 +441,7 @@ fn deserialize_uncompressed_g2(g2_bytes: &[u8]) -> Result<ECP2, AmclError> {
             }
         }
 
-        return Ok(ECP2::new());
+        return Ok(ECP2::new()); // infinity
     }
 
     if (g2_bytes[0] & Y_FLAG) > 0 {

--- a/src/bls381/core.rs
+++ b/src/bls381/core.rs
@@ -561,7 +561,6 @@ pub(crate) fn aggregate_g2(points: &[&[u8]]) -> Result<[u8; G2_BYTES], AmclError
         return Err(AmclError::AggregateEmptyPoints);
     }
 
-    // TODO: Error if bytes are invalid
     let mut aggregate = deserialize_g2(&points[0])?;
     for point in points.iter().skip(1) {
         aggregate.add(&deserialize_g2(&point)?);

--- a/src/bls381/core.rs
+++ b/src/bls381/core.rs
@@ -125,6 +125,7 @@ fn zcash_cmp_fp2(num1: &mut FP2, num2: &mut FP2) -> isize {
 }
 
 // Take a G1 point (x, y) and compress it to a 48 byte array.
+///
 // See https://github.com/zkcrypto/pairing/blob/master/src/bls12_381/README.md#serialization
 pub fn serialize_g1(g1: &ECP) -> [u8; G1_BYTES] {
     // Check point at inifinity
@@ -155,6 +156,9 @@ pub fn serialize_g1(g1: &ECP) -> [u8; G1_BYTES] {
     result
 }
 
+/// Take a G1 point (x, y) and converti it to a 96 byte array.
+///
+/// See https://github.com/zkcrypto/pairing/blob/master/src/bls12_381/README.md#serialization
 pub fn serialize_uncompressed_g1(g1: &ECP) -> [u8; G1_BYTES * 2] {
     // Check point at inifinity
     let mut result = [0u8; G1_BYTES * 2];
@@ -170,8 +174,9 @@ pub fn serialize_uncompressed_g1(g1: &ECP) -> [u8; G1_BYTES * 2] {
     result
 }
 
-// Take a 48 byte array and convert to a G1 point (x, y)
-// See https://github.com/zkcrypto/pairing/blob/master/src/bls12_381/README.md#serialization
+/// Take a 48 or 96 byte array and convert to a G1 point (x, y)
+///
+/// See https://github.com/zkcrypto/pairing/blob/master/src/bls12_381/README.md#serialization
 pub fn deserialize_g1(g1_bytes: &[u8]) -> Result<ECP, AmclError> {
     // Length must be 48 bytes
     if g1_bytes.len() == 0 {
@@ -186,6 +191,7 @@ pub fn deserialize_g1(g1_bytes: &[u8]) -> Result<ECP, AmclError> {
     }
 }
 
+// Deserialization of a G1 point from x-coordinate
 fn deserialize_compressed_g1(g1_bytes: &[u8]) -> Result<ECP, AmclError> {
     // Length must be 48 bytes
     if g1_bytes.len() != G1_BYTES {
@@ -239,6 +245,7 @@ fn deserialize_compressed_g1(g1_bytes: &[u8]) -> Result<ECP, AmclError> {
     }
 }
 
+// Deserialization of a G1 point from (x, y).
 fn deserialize_uncompressed_g1(g1_bytes: &[u8]) -> Result<ECP, AmclError> {
     // Length must be 96 bytes
     if g1_bytes.len() != G1_BYTES * 2 {
@@ -288,8 +295,9 @@ fn deserialize_uncompressed_g1(g1_bytes: &[u8]) -> Result<ECP, AmclError> {
     Ok(point)
 }
 
-// Take a GroupG2 point (x, y) and compress it to a 384*2 bit array.
-// See https://github.com/zkcrypto/pairing/blob/master/src/bls12_381/README.md#serialization
+/// Take a GroupG2 point (x, y) and compress it to a 96 byte array as the x-coordinate.
+///
+/// See https://github.com/zkcrypto/pairing/blob/master/src/bls12_381/README.md#serialization
 pub fn serialize_g2(g2: &ECP2) -> [u8; G2_BYTES] {
     // Check point at inifinity
     if g2.is_infinity() {
@@ -320,6 +328,9 @@ pub fn serialize_g2(g2: &ECP2) -> [u8; G2_BYTES] {
     result
 }
 
+/// Take a GroupG2 point (x, y) and convert it to a 192 byte array as (x, y).
+///
+/// See https://github.com/zkcrypto/pairing/blob/master/src/bls12_381/README.md#serialization
 pub fn serialize_uncompressed_g2(g2: &ECP2) -> [u8; G2_BYTES * 2] {
     let mut result = [0; G2_BYTES * 2];
 
@@ -343,8 +354,9 @@ pub fn serialize_uncompressed_g2(g2: &ECP2) -> [u8; G2_BYTES * 2] {
     result
 }
 
-// Take a 96 byte array and convert to G2 point (x, y)
-// See https://github.com/zkcrypto/pairing/blob/master/src/bls12_381/README.md#serialization
+/// Take a 96 or 192 byte array and convert to G2 point (x, y)
+///
+/// See https://github.com/zkcrypto/pairing/blob/master/src/bls12_381/README.md#serialization
 pub fn deserialize_g2(g2_bytes: &[u8]) -> Result<ECP2, AmclError> {
     if g2_bytes.len() == 0 {
         return Err(AmclError::InvalidG2Size);
@@ -358,6 +370,7 @@ pub fn deserialize_g2(g2_bytes: &[u8]) -> Result<ECP2, AmclError> {
     }
 }
 
+// Decompress a G2 point from x-coordinate
 fn deserialize_compressed_g2(g2_bytes: &[u8]) -> Result<ECP2, AmclError> {
     if g2_bytes.len() != G2_BYTES {
         return Err(AmclError::InvalidG2Size);
@@ -412,6 +425,7 @@ fn deserialize_compressed_g2(g2_bytes: &[u8]) -> Result<ECP2, AmclError> {
     }
 }
 
+// Decompress a G2 point from (x, y)
 fn deserialize_uncompressed_g2(g2_bytes: &[u8]) -> Result<ECP2, AmclError> {
     if g2_bytes.len() != G2_BYTES * 2 {
         return Err(AmclError::InvalidG2Size);

--- a/src/bls381/message_augmentation.rs
+++ b/src/bls381/message_augmentation.rs
@@ -4,6 +4,12 @@ use super::core::{G1_BYTES, G2_BYTES, SECRET_KEY_BYTES};
 use errors::AmclError;
 use rand::RAND;
 
+// Re-export serialization functions.
+pub use super::core::{
+    deserialize_g1, deserialize_g2, serialize_g1, serialize_g2, serialize_uncompressed_g1,
+    serialize_uncompressed_g2,
+};
+
 /// Domain Separation Tag for signatures on G1
 pub const DST_G1: &[u8] = b"BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_AUG_";
 /// Domain Separation Tag for signatures on G2

--- a/src/bls381/proof_of_possession.rs
+++ b/src/bls381/proof_of_possession.rs
@@ -3,13 +3,18 @@ use super::super::ecp2::ECP2;
 use super::super::pair;
 use super::core;
 use super::core::{
-    deserialize_g1, deserialize_g2, hash_to_curve_g1, hash_to_curve_g2, secret_key_from_bytes,
-    serialize_g1, serialize_g2, subgroup_check_g1, subgroup_check_g2, G1_BYTES, G2_BYTES,
-    SECRET_KEY_BYTES,
+    hash_to_curve_g1, hash_to_curve_g2, secret_key_from_bytes, subgroup_check_g1,
+    subgroup_check_g2, G1_BYTES, G2_BYTES, SECRET_KEY_BYTES,
 };
 
 use errors::AmclError;
 use rand::RAND;
+
+// Re-export serialization functions.
+pub use super::core::{
+    deserialize_g1, deserialize_g2, serialize_g1, serialize_g2, serialize_uncompressed_g1,
+    serialize_uncompressed_g2,
+};
 
 /// Domain Separation Tag for signatures on G1
 pub const DST_G1: &[u8] = b"BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_POP_";

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,4 +4,8 @@ pub enum AmclError {
     HashToFieldError,
     InvalidSecretKeySize,
     InvalidSecretKeyRange,
+    InvalidPoint,
+    InvalidG1Size,
+    InvalidG2Size,
+    InvalidCompressionFlag,
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -7,5 +7,5 @@ pub enum AmclError {
     InvalidPoint,
     InvalidG1Size,
     InvalidG2Size,
-    InvalidCompressionFlag,
+    InvalidYFlag,
 }


### PR DESCRIPTION
# Issue Addressed

#25 

# What has been changes

Implementation of the [ZCash](https://github.com/zkcrypto/pairing/blob/master/src/bls12_381/README.md#serialization) serialisation format for BLS381 G1 and G2 points.

This is the encoding that is references in the [BLS standard](https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-02#appendix-A).