### PR TITLE
Fuzz BLS381 Serialization

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,33 @@
+
+[package]
+name = "amcl-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.2"
+
+[dependencies.amcl]
+path = ".."
+features = ["all"]
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "bls381_deserialize_g1"
+path = "fuzz_targets/bls381_deserialize_g1.rs"
+
+[[bin]]
+name = "bls381_deserialize_g2"
+path = "fuzz_targets/bls381_deserialize_g2.rs"
+
+[[bin]]
+name = "bls381_secret_key_from_bytes"
+path = "fuzz_targets/bls381_secret_key_from_bytes.rs"

--- a/fuzz/fuzz_targets/bls381_deserialize_g1.rs
+++ b/fuzz/fuzz_targets/bls381_deserialize_g1.rs
@@ -1,0 +1,14 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use amcl::bls381::bls381::utils::{deserialize_g1, serialize_uncompressed_g1, serialize_g1};
+
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(point) = deserialize_g1(data) {
+        let compressed = serialize_g1(&point).to_vec();
+        let uncompressed = serialize_uncompressed_g1(&point).to_vec();
+
+        let data = data.to_vec();
+        assert!(compressed == data || uncompressed == data );
+    }
+});

--- a/fuzz/fuzz_targets/bls381_deserialize_g2.rs
+++ b/fuzz/fuzz_targets/bls381_deserialize_g2.rs
@@ -1,0 +1,13 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use amcl::bls381::bls381::utils::{deserialize_g2, serialize_uncompressed_g2, serialize_g2};
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(point) = deserialize_g2(data) {
+        let compressed = serialize_g2(&point).to_vec();
+        let uncompressed = serialize_uncompressed_g2(&point).to_vec();
+
+        let data = data.to_vec();
+        assert!(compressed == data || uncompressed == data );
+    }
+});

--- a/fuzz/fuzz_targets/bls381_secret_key_from_bytes.rs
+++ b/fuzz/fuzz_targets/bls381_secret_key_from_bytes.rs
@@ -1,0 +1,11 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use amcl::bls381::bls381::utils::{secret_key_to_bytes, secret_key_from_bytes};
+
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(big) = secret_key_from_bytes(data) {
+        let round_trip = secret_key_to_bytes(&big);
+        assert_eq!(data, round_trip);
+    }
+});


### PR DESCRIPTION
# What has been done

Fuzz targets for BLS12-381 serialisation have been added to ensure there are no panics in the serialization functions.

Fuzzers can be run as follows (e.g. for `bls381_deserialize_g1`)
```
cargo fuzz run bls381_deserialize_g1
```

Note it must be run in nightly (`rustup default nightly`).